### PR TITLE
Fixed problems with maintaining precision on a number amount

### DIFF
--- a/src/lib/txToTxrep.ts
+++ b/src/lib/txToTxrep.ts
@@ -8,6 +8,7 @@ import {
   xdr
 } from 'stellar-sdk';
 
+import BigNumber from 'bignumber.js';
 import { best_r, upperSnakeCase } from './utils';
 
 type LineAdder = (k: string, v: any, optional?: boolean) => void;
@@ -267,7 +268,7 @@ function addChangeTrustOp(
 ) {
   addBodyLine('line', toAsset(operation.line));
   if (operation.limit) {
-    addBodyLine('limit', toAmount(operation.limit));
+    addBodyLine('limit', toLimit(operation.limit));
   }
 }
 
@@ -344,6 +345,10 @@ function toAsset(asset: Asset) {
 
 function toAmount(amount: string) {
   return Number(amount) * 10000000;
+}
+
+function toLimit(limit: string) {
+  return new BigNumber(limit).times(10000000)
 }
 
 function toString(value: string) {

--- a/src/lib/txrepToTx.ts
+++ b/src/lib/txrepToTx.ts
@@ -380,7 +380,7 @@ function toChangeTrust(op: ChangeTrustOp, source: string) {
   const { line, limit } = op;
   return Operation.changeTrust({
     asset: toAsset(line),
-    limit: limit && toAmount(limit),
+    limit: limit && toLimit(limit),
     source
   });
 }
@@ -486,6 +486,10 @@ function toTimebounds(timeBounds) {
 
 function toAmount(amount: string) {
   return new BigNumber(amount).div(10000000).toFixed(10);
+}
+
+function toLimit(limit: string) {
+  return new BigNumber(limit).div(10000000).toFixed(7);
 }
 
 function toPrice({ n, d }: { n: string; d: string }) {


### PR DESCRIPTION
Fix
Current behavior: the value of "change trust limit"  after converting from Tx to Txrep loses its precision. 
Possible crash of change_trust operations in @stellarguard/stellar-uri when calling replace.
https://www.stellar.org/developers/guides/concepts/assets.html#amount-precision-and-representation

New behavior: using bignumber.js for fix problems with maintaining precision 
https://www.stellar.org/developers/guides/concepts/assets.html#maintaining-precision-with-big-number-libraries

